### PR TITLE
fix: 🐛 "タブバーを透明にする"のコードを修正

### DIFF
--- a/articles/mozumasu-wezterm-customization.md
+++ b/articles/mozumasu-wezterm-customization.md
@@ -651,7 +651,11 @@ config.window_background_opacity = 0.85
 config.macos_window_background_blur = 20
 config.window_decorations = "RESIZE"
 config.hide_tab_bar_if_only_one_tab = true
-+ config.hide_tab_bar_if_only_one_tab = true
+
++ config.window_frame = {
++   inactive_titlebar_bg = "none",
++   active_titlebar_bg = "none",
++ }
 
 return config
 ```


### PR DESCRIPTION
[モテるターミナルにカスタマイズしよう（wezterm）](https://zenn.dev/mozumasu/articles/mozumasu-wezterm-customization)の記事を拝読いたしました。私はWezTermの設定をあまりいじってこなかったのですが、こちらの記事に触発されて、カスタマイズを始めました。

その際に誤記と思われる箇所を見つけましたので、本PRにて修正させていただきました。
お手数ですが、ご確認をお願いいたします。

## 修正内容
- "タブバーを透明にする"の見出しに記載されている`wezterm.lua`を修正
  - 修正前: "タブが一つしかない時に非表示"に記載されているコードと同一になっていた
  - 修正後: `window_frame`を設定するコードに変更